### PR TITLE
Fix trying to check type for nil column

### DIFF
--- a/lib/activerecord-postgres-composite-types/active_record_3.rb
+++ b/lib/activerecord-postgres-composite-types/active_record_3.rb
@@ -86,7 +86,7 @@ module ActiveRecord
 			extend ActiveSupport::Concern
 
 			def type_cast_attribute_for_write(column, value)
-				if klass = column.composite_type_class
+				if column && klass = column.composite_type_class
 					# Cast Hash and Array to composite type klass
 					if value.is_a?(klass)
 						value


### PR DESCRIPTION
Sometimes column to check passed to `type_cast_attribute_for_write` is `nil`.
This kind of protection is implemented in ActiveRecord as well. 
